### PR TITLE
Fix typo (sorceror->sorcerer)

### DIFF
--- a/data/WOTC_5e_SRD_v5.1/classes.json
+++ b/data/WOTC_5e_SRD_v5.1/classes.json
@@ -197,7 +197,7 @@
 		}]
 	},
 	{
-		"name":"Sorceror",
+		"name":"Sorcerer",
 		"features" : {
 			"hit-dice":"1d6",
 			"hp-at-1st-level":"6 + your Constitution modifier",


### PR DESCRIPTION
Small typo in the sorcerer class name. 