### PR TITLE
Windows machine encoding bugfix

### DIFF
--- a/api/management/commands/populatedb.py
+++ b/api/management/commands/populatedb.py
@@ -41,72 +41,72 @@ class Command(BaseCommand):
 
         for dir in options['directory']:
             importer = i.Importer()
-            with open(dir+'document.json') as doc_data:
+            with open(dir+'document.json', encoding="latin-1") as doc_data:
                 docs = json.load(doc_data)
                 self.stdout.write(self.style.SUCCESS(importer.DocumentImporter(options, docs)))
             
             bgs_file = Path(dir+'backgrounds.json')
             if bgs_file.exists():
-                with open(bgs_file) as bg_data:
+                with open(bgs_file, encoding="latin-1") as bg_data:
                     bgs = json.load(bg_data)
                     self.stdout.write(self.style.SUCCESS(importer.BackgroundImporter(options, bgs)))
 
             cls_file = Path(dir+'classes.json')
             if cls_file.exists():
-                with open(cls_file) as cls_data:
+                with open(cls_file, encoding="latin-1") as cls_data:
                     cls = json.load(cls_data)
                     self.stdout.write(self.style.SUCCESS(importer.ClassImporter(options, cls)))
 
             con_file = Path(dir+'conditions.json')
             if con_file.exists():
-                with open(con_file) as con_data:
+                with open(con_file, encoding="latin-1") as con_data:
                     con = json.load(con_data)
                     self.stdout.write(self.style.SUCCESS(importer.ConditionImporter(options, con)))
 
             fea_file = Path(dir+'feats.json')
             if fea_file.exists():
-                with open(fea_file) as fea_data:
+                with open(fea_file, encoding="latin-1") as fea_data:
                     fea = json.load(fea_data)
                     self.stdout.write(self.style.SUCCESS(importer.FeatImporter(options, fea)))
 
             mag_file = Path(dir+'magicitems.json')
             if mag_file.exists():
-                with open(mag_file) as mag_data:
+                with open(mag_file, encoding="latin-1") as mag_data:
                     mag = json.load(mag_data)
                     self.stdout.write(self.style.SUCCESS(importer.MagicItemImporter(options, mag)))
 
             spl_file = Path(dir+'spells.json')
             if spl_file.exists():
-                with open(spl_file) as spl_data:
+                with open(spl_file, encoding="latin-1") as spl_data:
                     spl = json.load(spl_data)
                     self.stdout.write(self.style.SUCCESS(importer.SpellImporter(options, spl)))
 
             mon_file = Path(dir+'monsters.json')
             if mon_file.exists():
-                with open(mon_file) as mon_data:
+                with open(mon_file, encoding="latin-1") as mon_data:
                     mon = json.load(mon_data)
                     self.stdout.write(self.style.SUCCESS(importer.MonsterImporter(options, mon)))
 
             pln_file = Path(dir+'planes.json')
             if pln_file.exists():
-                with open(pln_file) as pln_data:
+                with open(pln_file, encoding="latin-1") as pln_data:
                     pln = json.load(pln_data)
                     self.stdout.write(self.style.SUCCESS(importer.PlaneImporter(options, pln)))
 
             sec_file = Path(dir+'sections.json')
             if sec_file.exists():
-                with open(sec_file) as sec_data:
+                with open(sec_file, encoding="latin-1") as sec_data:
                     sec = json.load(sec_data)
                     self.stdout.write(self.style.SUCCESS(importer.SectionImporter(options, sec)))
 
             rac_file = Path(dir+'races.json')
             if rac_file.exists():
-                with open(rac_file) as rac_data:
+                with open(rac_file, encoding="latin-1") as rac_data:
                     rac = json.load(rac_data)
                     self.stdout.write(self.style.SUCCESS(importer.RaceImporter(options, rac)))
 
             wea_file = Path(dir+'weapons.json')
             if wea_file.exists():
-                with open(wea_file) as wea_data:
+                with open(wea_file, encoding="latin-1") as wea_data:
                     wea = json.load(wea_data)
                     self.stdout.write(self.style.SUCCESS(importer.WeaponImporter(options, wea)))

--- a/api/management/commands/populatedb.py
+++ b/api/management/commands/populatedb.py
@@ -41,72 +41,72 @@ class Command(BaseCommand):
 
         for dir in options['directory']:
             importer = i.Importer()
-            with open(dir+'document.json', encoding="latin-1") as doc_data:
+            with open(dir+'document.json', encoding="utf-8") as doc_data:
                 docs = json.load(doc_data)
                 self.stdout.write(self.style.SUCCESS(importer.DocumentImporter(options, docs)))
             
             bgs_file = Path(dir+'backgrounds.json')
             if bgs_file.exists():
-                with open(bgs_file, encoding="latin-1") as bg_data:
+                with open(bgs_file, encoding="utf-8") as bg_data:
                     bgs = json.load(bg_data)
                     self.stdout.write(self.style.SUCCESS(importer.BackgroundImporter(options, bgs)))
 
             cls_file = Path(dir+'classes.json')
             if cls_file.exists():
-                with open(cls_file, encoding="latin-1") as cls_data:
+                with open(cls_file, encoding="utf-8") as cls_data:
                     cls = json.load(cls_data)
                     self.stdout.write(self.style.SUCCESS(importer.ClassImporter(options, cls)))
 
             con_file = Path(dir+'conditions.json')
             if con_file.exists():
-                with open(con_file, encoding="latin-1") as con_data:
+                with open(con_file, encoding="utf-8") as con_data:
                     con = json.load(con_data)
                     self.stdout.write(self.style.SUCCESS(importer.ConditionImporter(options, con)))
 
             fea_file = Path(dir+'feats.json')
             if fea_file.exists():
-                with open(fea_file, encoding="latin-1") as fea_data:
+                with open(fea_file, encoding="utf-8") as fea_data:
                     fea = json.load(fea_data)
                     self.stdout.write(self.style.SUCCESS(importer.FeatImporter(options, fea)))
 
             mag_file = Path(dir+'magicitems.json')
             if mag_file.exists():
-                with open(mag_file, encoding="latin-1") as mag_data:
+                with open(mag_file, encoding="utf-8") as mag_data:
                     mag = json.load(mag_data)
                     self.stdout.write(self.style.SUCCESS(importer.MagicItemImporter(options, mag)))
 
             spl_file = Path(dir+'spells.json')
             if spl_file.exists():
-                with open(spl_file, encoding="latin-1") as spl_data:
+                with open(spl_file, encoding="utf-8") as spl_data:
                     spl = json.load(spl_data)
                     self.stdout.write(self.style.SUCCESS(importer.SpellImporter(options, spl)))
 
             mon_file = Path(dir+'monsters.json')
             if mon_file.exists():
-                with open(mon_file, encoding="latin-1") as mon_data:
+                with open(mon_file, encoding="utf-8") as mon_data:
                     mon = json.load(mon_data)
                     self.stdout.write(self.style.SUCCESS(importer.MonsterImporter(options, mon)))
 
             pln_file = Path(dir+'planes.json')
             if pln_file.exists():
-                with open(pln_file, encoding="latin-1") as pln_data:
+                with open(pln_file, encoding="utf-8") as pln_data:
                     pln = json.load(pln_data)
                     self.stdout.write(self.style.SUCCESS(importer.PlaneImporter(options, pln)))
 
             sec_file = Path(dir+'sections.json')
             if sec_file.exists():
-                with open(sec_file, encoding="latin-1") as sec_data:
+                with open(sec_file, encoding="utf-8") as sec_data:
                     sec = json.load(sec_data)
                     self.stdout.write(self.style.SUCCESS(importer.SectionImporter(options, sec)))
 
             rac_file = Path(dir+'races.json')
             if rac_file.exists():
-                with open(rac_file, encoding="latin-1") as rac_data:
+                with open(rac_file, encoding="utf-8") as rac_data:
                     rac = json.load(rac_data)
                     self.stdout.write(self.style.SUCCESS(importer.RaceImporter(options, rac)))
 
             wea_file = Path(dir+'weapons.json')
             if wea_file.exists():
-                with open(wea_file, encoding="latin-1") as wea_data:
+                with open(wea_file, encoding="utf-8") as wea_data:
                     wea = json.load(wea_data)
                     self.stdout.write(self.style.SUCCESS(importer.WeaponImporter(options, wea)))


### PR DESCRIPTION
Noticed encoding issues for the database, preventing indexing of everything except first two spell items, on a windows machine. Resolved by forcing 'encoding="latin-1"' for each file section in api/management/commands/populateddb.py