### PR TITLE
Monster data corrections

### DIFF
--- a/data/WOTC_5e_SRD_v5.1/monsters.json
+++ b/data/WOTC_5e_SRD_v5.1/monsters.json
@@ -59,7 +59,7 @@
             },
             {
                 "name": "Tail",
-                "desc": "Melee Weapon Attack: +9 to hit, reach 10 ft. one target. Hit: 15 (3d6 + 5) bludgeoning damage.",
+                "desc": "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 15 (3d6 + 5) bludgeoning damage.",
                 "attack_bonus": 9,
                 "damage_dice": "3d6",
                 "damage_bonus": 5
@@ -399,7 +399,7 @@
             },
             {
                 "name": "Bite",
-                "desc": "Melee Weapon Attack: +11 to hit, reach,.0 ft., one target. Hit: 17 (2d10 + 6) piercing damage.",
+                "desc": "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage.",
                 "attack_bonus": 11,
                 "damage_dice": "2d10",
                 "damage_bonus": 6
@@ -1311,7 +1311,7 @@
             },
             {
                 "name": "Bite",
-                "desc": "Melee Weapon Attack:+ 15 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage plus 9 (2d8) acid damage.",
+                "desc": "Melee Weapon Attack: +15 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage plus 9 (2d8) acid damage.",
                 "attack_bonus": 15,
                 "damage_dice": "2d10+2d8",
                 "damage_bonus": 8
@@ -1325,7 +1325,7 @@
             },
             {
                 "name": "Tail",
-                "desc": "Melee Weapon Attack: +15 to hit, reach 20 ft ., one target. Hit: 17 (2d8 + 8) bludgeoning damage.",
+                "desc": "Melee Weapon Attack: +15 to hit, reach 20 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage.",
                 "attack_bonus": 15,
                 "damage_dice": "2d8",
                 "damage_bonus": 8
@@ -3120,7 +3120,7 @@
             },
             {
                 "name": "Light Crossbow",
-                "desc": "Ranged Weapon Attack: +3 to hit, range 80 ft./320 ft., one target. Hit: 5 (1d8 + 1) piercing damage.",
+                "desc": "Ranged Weapon Attack: +3 to hit, range 80/320 ft., one target. Hit: 5 (1d8 + 1) piercing damage.",
                 "attack_bonus": 3,
                 "damage_dice": "1d8",
                 "damage_bonus": 1
@@ -3248,7 +3248,7 @@
             },
             {
                 "name": "Claw",
-                "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft ., one target. Hit: 6 (1d6 + 3) piercing damage.",
+                "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.",
                 "attack_bonus": 6,
                 "damage_dice": "1d6",
                 "damage_bonus": 3
@@ -9178,7 +9178,7 @@
             },
             {
                 "name": "Spear",
-                "desc": "Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. and range 20/60 ft., one target. Hit: 11 (2d6 + 4) piercing damage, or 13 (2d8 + 4) piercing damage if used with two hands to make a melee attack.",
+                "desc": "Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 11 (2d6 + 4) piercing damage, or 13 (2d8 + 4) piercing damage if used with two hands to make a melee attack.",
                 "attack_bonus": 7,
                 "damage_dice": "2d6",
                 "damage_bonus": 4
@@ -11003,7 +11003,7 @@
         "actions": [
             {
                 "name": "Sting (Bite in Beast Form)",
-                "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft ., one target. Hit: 5 (1d4 + 3) piercing damage, and the target must make on a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one.",
+                "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 5 (1d4 + 3) piercing damage, and the target must make on a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one.",
                 "attack_bonus": 5,
                 "damage_dice": "1d4",
                 "damage_bonus": 3
@@ -12011,7 +12011,7 @@
         "actions": [
             {
                 "name": "Claws",
-                "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft ., one creature. Hit: 3 (1d4 + 1) slashing damage plus 2 (1d4) fire damage.",
+                "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 3 (1d4 + 1) slashing damage plus 2 (1d4) fire damage.",
                 "attack_bonus": 3,
                 "damage_dice": "1d4",
                 "damage_bonus": 1
@@ -12366,7 +12366,7 @@
         "actions": [
             {
                 "name": "Multiattack",
-                "desc": "The medusa makes either three melee attacks -  one with its snake hair and two with its shortsword - or two ranged attacks with its longbow.",
+                "desc": "The medusa makes either three melee attacks - one with its snake hair and two with its shortsword - or two ranged attacks with its longbow.",
                 "attack_bonus": 0
             },
             {
@@ -12936,7 +12936,7 @@
         "actions": [
             {
                 "name": "Multiattack",
-                "desc": "The nalfeshnee uses Horror Nimbus if it can.  It then makes three attacks: one with its bite and two with its claws.",
+                "desc": "The nalfeshnee uses Horror Nimbus if it can. It then makes three attacks: one with its bite and two with its claws.",
                 "attack_bonus": 0
             },
             {
@@ -13924,21 +13924,21 @@
             },
             {
                 "name": "Claw",
-                "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft. , one target. Hit: 17 (2d8 + 8) slashing damage.",
+                "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 17 (2d8 + 8) slashing damage.",
                 "attack_bonus": 14,
                 "damage_dice": "2d8",
                 "damage_bonus": 8
             },
             {
                 "name": "Mace",
-                "desc": "Melee Weapon Attack: +14 to hit, reach 10ft., one target. Hit: 15 (2d6 + 8) bludgeoning damage plus 21 (6d6) fire damage.",
+                "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 15 (2d6 + 8) bludgeoning damage plus 21 (6d6) fire damage.",
                 "attack_bonus": 14,
                 "damage_dice": "2d6",
                 "damage_bonus": 8
             },
             {
                 "name": "Tail",
-                "desc": "Melee Weapon Attack: +14 to hit, reach 10ft., one target. Hit: 24 (3d1O + 8) bludgeoning damage.",
+                "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 24 (3d1O + 8) bludgeoning damage.",
                 "attack_bonus": 14,
                 "damage_dice": "3d10",
                 "damage_bonus": 8
@@ -14451,7 +14451,7 @@
         "actions": [
             {
                 "name": "Claw (Bite in Beast Form)",
-                "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft ., one target. Hit: 5 (1d4 + 3) piercing damage, and the target must succeed on a DC 10 Constitution saving throw or take 5 (2d4) poison damage and become poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+                "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d4 + 3) piercing damage, and the target must succeed on a DC 10 Constitution saving throw or take 5 (2d4) poison damage and become poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
                 "attack_bonus": 4,
                 "damage_dice": "1d4",
                 "damage_bonus": 3
@@ -15327,7 +15327,7 @@
             },
             {
                 "name": "Spear",
-                "desc": "Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20 ft./60 ft., one target. Hit: 11 (2d6 + 4) piercing damage, or 13 (2d8 + 4) piercing damage if used with two hands to make a melee attack, plus 3 (1d6) fire damage.",
+                "desc": "Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 11 (2d6 + 4) piercing damage, or 13 (2d8 + 4) piercing damage if used with two hands to make a melee attack, plus 3 (1d6) fire damage.",
                 "attack_bonus": 7,
                 "damage_dice": "2d6",
                 "damage_bonus": 4
@@ -15496,7 +15496,7 @@
             },
             {
                 "name": "Longbow",
-                "desc": "Ranged Weapon Attack: +4 to hit, ranged 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.",
+                "desc": "Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.",
                 "attack_bonus": 4,
                 "damage_dice": "1d8",
                 "damage_bonus": 2
@@ -17789,14 +17789,14 @@
             },
             {
                 "name": "Hooves",
-                "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft ., one target. Hit: 11 (2d6 + 4) bludgeoning damage.",
+                "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage.",
                 "attack_bonus": 7,
                 "damage_dice": "2d6",
                 "damage_bonus": 4
             },
             {
                 "name": "Horn",
-                "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft ., one target. Hit: 8 (1d8 + 4) piercing damage.",
+                "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) piercing damage.",
                 "attack_bonus": 7,
                 "damage_dice": "1d8",
                 "damage_bonus": 4

--- a/data/WOTC_5e_SRD_v5.1/monsters.json
+++ b/data/WOTC_5e_SRD_v5.1/monsters.json
@@ -127,11 +127,11 @@
             }
         ],
         "spells": [
-            "light", 
-            "sacred-flame", 
+            "light",
+            "sacred-flame",
             "thaumaturgy",
             "bless",
-            "cure-wounds", 
+            "cure-wounds",
             "sanctuary"
         ],
         "actions": [
@@ -2379,20 +2379,20 @@
             }
         ],
         "spells": [
-            "sacred-flame", 
-            "spare the dying", 
+            "sacred-flame",
+            "spare the dying",
             "thaumaturgy",
-            "command", 
-            "detect evil and good", 
+            "command",
+            "detect evil and good",
             "detect magic",
-            "lesser restoration", 
+            "lesser restoration",
             "zone of truth",
-            "dispel magic", 
+            "dispel magic",
             "tongues",
-            "banishment", 
+            "banishment",
             "freedom of movement",
-            "flame strike", 
-            "greater restoration", 
+            "flame strike",
+            "greater restoration",
             "heroes' feast"
         ],
         "actions": [
@@ -2629,19 +2629,19 @@
             }
         ],
         "spells": [
-            "sacred-flame", 
-            "spare-the-dying", 
+            "sacred-flame",
+            "spare-the-dying",
             "thaumaturgy",
-            "command", 
-            "detect-evil-and-good", 
+            "command",
+            "detect-evil-and-good",
             "detect-magic",
-            "lesser-restoration", 
+            "lesser-restoration",
             "zone-of-truth",
-            "dispel-magic", 
+            "dispel-magic",
             "tongues",
-            "banishment", 
+            "banishment",
             "freedom-of-movement",
-            "flame-strike", 
+            "flame-strike",
             "greater-restoration",
             "heroes-feast"
         ],
@@ -5071,18 +5071,18 @@
             }
         ],
         "spells": [
-            "detect evil and good", 
-            "detect magic", 
+            "detect evil and good",
+            "detect magic",
             "detect thoughts",
-            "bless", 
-            "create food and water", 
-            "cure wounds", 
-            "lesser restoration", 
-            "protection from poison", 
-            "sanctuary", 
+            "bless",
+            "create food and water",
+            "cure wounds",
+            "lesser restoration",
+            "protection from poison",
+            "sanctuary",
             "shield",
-            "dream", 
-            "greater restoration", 
+            "dream",
+            "greater restoration",
             "scrying"
         ],
         "actions": [
@@ -5242,13 +5242,13 @@
             }
         ],
         "spells": [
-            "light", 
-            "sacred flame", 
-            "thaumaturgy", 
-            "command", 
-            "inflict wounds", 
-            "shield of faith", 
-            "hold person", 
+            "light",
+            "sacred flame",
+            "thaumaturgy",
+            "command",
+            "inflict wounds",
+            "shield of faith",
+            "hold person",
             "spiritual weapon"
         ],
         "actions": [
@@ -5465,9 +5465,9 @@
             }
         ],
         "spells": [
-            "nondetection", 
-            "blindness/deafness", 
-            "blur", 
+            "nondetection",
+            "blindness/deafness",
+            "blur",
             "disguise self"
         ],
         "actions": [
@@ -5572,7 +5572,7 @@
         ],
         "spells": [
             "detect evil and good",
-            "commune", 
+            "commune",
             "raise dead"
         ],
         "actions": [
@@ -5701,16 +5701,16 @@
             }
         ],
         "spells": [
-            "detect evil and good", 
-            "detect magic", 
-            "create food and water", 
-            "tongues", 
+            "detect evil and good",
+            "detect magic",
+            "create food and water",
+            "tongues",
             "wind walk",
-            "conjure elemental", 
-            "creation", 
-            "gaseous form", 
-            "invisibility", 
-            "major image", 
+            "conjure elemental",
+            "creation",
+            "gaseous form",
+            "invisibility",
+            "major image",
             "plane shift"
         ],
         "actions": [
@@ -6020,8 +6020,8 @@
             }
         ],
         "spells": [
-            "dancing lights", 
-            "darkness", 
+            "dancing lights",
+            "darkness",
             "faerie fire"
         ],
         "actions": [
@@ -6102,7 +6102,7 @@
         ],
         "spells": [
             "dancing lights",
-            "darkness", 
+            "darkness",
             "faerie fire"
         ],
         "actions": [
@@ -6160,14 +6160,14 @@
             }
         ],
         "spells": [
-            "druidcraft", 
-            "produce flame", 
-            "shillelagh", 
-            "entangle", 
-            "longstrider", 
-            "speak with animals", 
-            "thunderwave", 
-            "animal messenger", 
+            "druidcraft",
+            "produce flame",
+            "shillelagh",
+            "entangle",
+            "longstrider",
+            "speak with animals",
+            "thunderwave",
+            "animal messenger",
             "barkskin"
         ],
         "actions": [
@@ -6231,11 +6231,11 @@
             }
         ],
         "spells": [
-            "druidcraft", 
+            "druidcraft",
             "entangle",
-            "goodberry", 
-            "barkskin", 
-            "pass without trace", 
+            "goodberry",
+            "barkskin",
+            "pass without trace",
             "shillelagh"
         ],
         "actions": [
@@ -6532,14 +6532,14 @@
             }
         ],
         "spells": [
-            "detect magic", 
-            "enlarge/reduce", 
-            "tongues", 
-            "conjure elemental", 
-            "gaseous form", 
-            "invisibility", 
-            "major image", 
-            "plane shift", 
+            "detect magic",
+            "enlarge/reduce",
+            "tongues",
+            "conjure elemental",
+            "gaseous form",
+            "invisibility",
+            "major image",
+            "plane shift",
             "wall of fire"
         ],
         "actions": [
@@ -9091,11 +9091,11 @@
             }
         ],
         "spells": [
-            "darkness", 
-            "detect magic", 
-            "dispel magic", 
-            "confusion", 
-            "fly", 
+            "darkness",
+            "detect magic",
+            "dispel magic",
+            "confusion",
+            "fly",
             "power word stun"
         ],
         "actions": [
@@ -9653,20 +9653,20 @@
             }
         ],
         "spells": [
-            "dancing lights", 
-            "minor illusion", 
-            "vicious mockery", 
-            "identify", 
-            "ray of sickness", 
-            "hold person", 
-            "locate object", 
-            "bestow curse", 
-            "counterspell", 
-            "lightning bolt", 
-            "phantasmal killer", 
-            "polymorph", 
-            "contact other plane", 
-            "scrying", 
+            "dancing lights",
+            "minor illusion",
+            "vicious mockery",
+            "identify",
+            "ray of sickness",
+            "hold person",
+            "locate object",
+            "bestow curse",
+            "counterspell",
+            "lightning bolt",
+            "phantasmal killer",
+            "polymorph",
+            "contact other plane",
+            "scrying",
             "eye bite"
         ],
         "actions": [
@@ -9943,20 +9943,20 @@
             }
         ],
         "spells": [
-            "mending", 
-            "sacred flame", 
-            "thaumaturgy", 
-            "command", 
-            "cure wounds", 
-            "shield of faith", 
-            "calm emotions", 
-            "hold person", 
-            "bestow curse", 
-            "clairvoyance", 
-            "banishment", 
-            "freedom of movement", 
-            "flame strike", 
-            "geas", 
+            "mending",
+            "sacred flame",
+            "thaumaturgy",
+            "command",
+            "cure wounds",
+            "shield of faith",
+            "calm emotions",
+            "hold person",
+            "bestow curse",
+            "clairvoyance",
+            "banishment",
+            "freedom of movement",
+            "flame strike",
+            "geas",
             "true seeing"
         ],
         "actions": [
@@ -10025,20 +10025,20 @@
             }
         ],
         "spells": [
-            "mage hand", 
-            "minor illusion", 
-            "prestidigitation", 
-            "detect magic", 
-            "identify", 
-            "shield", 
-            "darkness", 
-            "locate object", 
-            "suggestion", 
-            "dispel magic", 
-            "remove curse", 
-            "tongues", 
-            "banishment", 
-            "greater invisibility", 
+            "mage hand",
+            "minor illusion",
+            "prestidigitation",
+            "detect magic",
+            "identify",
+            "shield",
+            "darkness",
+            "locate object",
+            "suggestion",
+            "dispel magic",
+            "remove curse",
+            "tongues",
+            "banishment",
+            "greater invisibility",
             "legend lore"
         ],
         "actions": [
@@ -11516,12 +11516,12 @@
             }
         ],
         "spells": [
-            "disguise self", 
-            "major image", 
-            "charm person", 
-            "mirror image", 
-            "scrying", 
-            "suggestion", 
+            "disguise self",
+            "major image",
+            "charm person",
+            "mirror image",
+            "scrying",
+            "suggestion",
             "geas"
         ],
         "actions": [
@@ -11656,31 +11656,31 @@
             }
         ],
         "spells": [
-            "mage hand", 
-            "prestidigitation", 
-            "ray of frost", 
-            "detect magic", 
-            "magic missile", 
-            "shield", 
+            "mage hand",
+            "prestidigitation",
+            "ray of frost",
+            "detect magic",
+            "magic missile",
+            "shield",
             "thunderwave",
-            "detect thoughts", 
-            "invisibility", 
-            "acid arrow", 
-            "mirror image", 
-            "animate dead", 
-            "counterspell", 
-            "dispel magic", 
-            "fireball", 
-            "blight", 
-            "dimension door", 
-            "cloudkill", 
-            "scrying", 
-            "disintegrate", 
-            "globe of invulnerability", 
-            "finger of death", 
-            "plane shift", 
-            "dominate monster", 
-            "power word stun", 
+            "detect thoughts",
+            "invisibility",
+            "acid arrow",
+            "mirror image",
+            "animate dead",
+            "counterspell",
+            "dispel magic",
+            "fireball",
+            "blight",
+            "dimension door",
+            "cloudkill",
+            "scrying",
+            "disintegrate",
+            "globe of invulnerability",
+            "finger of death",
+            "plane shift",
+            "dominate monster",
+            "power word stun",
             "power word kill"
         ],
         "actions": [
@@ -11932,21 +11932,21 @@
             }
         ],
         "spells": [
-            "fire bolt", 
-            "light", 
-            "mage hand", 
-            "prestidigitation", 
-            "detect magic", 
-            "mage armor", 
-            "magic missile", 
-            "shield", 
-            "misty step", 
-            "suggestion", 
-            "counterspell", 
-            "fireball", 
-            "fly", 
-            "greater invisibility", 
-            "ice storm", 
+            "fire bolt",
+            "light",
+            "mage hand",
+            "prestidigitation",
+            "detect magic",
+            "mage armor",
+            "magic missile",
+            "shield",
+            "misty step",
+            "suggestion",
+            "counterspell",
+            "fireball",
+            "fly",
+            "greater invisibility",
+            "ice storm",
             "cone of cold"
         ],
         "actions": [
@@ -12830,20 +12830,20 @@
             }
         ],
         "spells": [
-            "sacred flame", 
-            "thaumaturgy", 
-            "command", 
-            "guiding bolt", 
-            "shield of faith", 
-            "hold person", 
-            "silence", 
-            "spiritual weapon", 
-            "animate dead", 
-            "dispel magic", 
-            "divination", 
-            "guardian of faith", 
-            "contagion", 
-            "insect plague", 
+            "sacred flame",
+            "thaumaturgy",
+            "command",
+            "guiding bolt",
+            "shield of faith",
+            "hold person",
+            "silence",
+            "spiritual weapon",
+            "animate dead",
+            "dispel magic",
+            "divination",
+            "guardian of faith",
+            "contagion",
+            "insect plague",
             "harm"
         ],
         "actions": [
@@ -13036,22 +13036,22 @@
             }
         ],
         "spells": [
-            "detect magic", 
-            "magic missile", 
-            "plane shift", 
-            "ray of enfeeblement", 
-            "sleep", 
-            "identify", 
-            "ray of sickness", 
-            "hold person", 
-            "locate object", 
-            "bestow curse", 
-            "counterspell", 
-            "lightning bolt", 
-            "phantasmal killer", 
-            "polymorph", 
-            "contact other plane", 
-            "scrying", 
+            "detect magic",
+            "magic missile",
+            "plane shift",
+            "ray of enfeeblement",
+            "sleep",
+            "identify",
+            "ray of sickness",
+            "hold person",
+            "locate object",
+            "bestow curse",
+            "counterspell",
+            "lightning bolt",
+            "phantasmal killer",
+            "polymorph",
+            "contact other plane",
+            "scrying",
             "eye bite"
         ],
         "actions": [
@@ -13440,11 +13440,11 @@
             }
         ],
         "spells": [
-            "darkness", 
-            "invisibility", 
-            "charm person", 
-            "cone of cold", 
-            "gaseous form", 
+            "darkness",
+            "invisibility",
+            "charm person",
+            "cone of cold",
+            "gaseous form",
             "sleep"
         ],
         "actions": [
@@ -13904,9 +13904,9 @@
             }
         ],
         "spells": [
-            "detect magic", 
-            "fireball", 
-            "hold monster", 
+            "detect magic",
+            "fireball",
+            "hold monster",
             "wall of fire"
         ],
         "actions": [
@@ -14001,14 +14001,14 @@
             }
         ],
         "spells": [
-            "detect evil and good", 
-            "invisibility", 
-            "blade barrier", 
-            "dispel evil and good", 
-            "flame strike", 
-            "raise dead", 
-            "commune", 
-            "control weather", 
+            "detect evil and good",
+            "invisibility",
+            "blade barrier",
+            "dispel evil and good",
+            "flame strike",
+            "raise dead",
+            "commune",
+            "control weather",
             "insect plague"
         ],
         "actions": [
@@ -14255,15 +14255,15 @@
             }
         ],
         "spells": [
-            "light", 
-            "sacred flame", 
-            "thaumaturgy", 
-            "cure wounds", 
-            "guiding bolt", 
-            "sanctuary", 
-            "lesser restoration", 
-            "spiritual weapon", 
-            "dispel magic", 
+            "light",
+            "sacred flame",
+            "thaumaturgy",
+            "cure wounds",
+            "guiding bolt",
+            "sanctuary",
+            "lesser restoration",
+            "spiritual weapon",
+            "dispel magic",
             "spirit guardians"
         ],
         "actions": [
@@ -14557,18 +14557,18 @@
             }
         ],
         "spells": [
-            "detect thoughts", 
-            "disguise self", 
-            "mage hand", 
-            "minor illusion", 
-            "charm person", 
-            "detect magic", 
-            "invisibility", 
-            "major image", 
-            "suggestion", 
-            "dominate person", 
-            "fly", 
-            "plane shift", 
+            "detect thoughts",
+            "disguise self",
+            "mage hand",
+            "minor illusion",
+            "charm person",
+            "detect magic",
+            "invisibility",
+            "major image",
+            "suggestion",
+            "dominate person",
+            "fly",
+            "plane shift",
             "true seeing"
         ],
         "actions": [
@@ -15558,17 +15558,17 @@
             }
         ],
         "spells": [
-            "identify", 
-            "ray of sickness", 
-            "hold person", 
-            "locate object", 
-            "bestow curse", 
-            "counterspell", 
-            "lightning bolt", 
-            "phantasmal killer", 
-            "polymorph", 
-            "contact other plane", 
-            "scrying", 
+            "identify",
+            "ray of sickness",
+            "hold person",
+            "locate object",
+            "bestow curse",
+            "counterspell",
+            "lightning bolt",
+            "phantasmal killer",
+            "polymorph",
+            "contact other plane",
+            "scrying",
             "eye bite"
         ],
         "actions": [
@@ -15995,12 +15995,12 @@
             }
         ],
         "spells": [
-            "detect evil and good", 
-            "invisibility", 
-            "blade barrier", 
-            "dispel evil and good", 
-            "resurrection", 
-            "commune", 
+            "detect evil and good",
+            "invisibility",
+            "blade barrier",
+            "dispel evil and good",
+            "resurrection",
+            "commune",
             "control weather"
         ],
         "actions": [
@@ -16202,18 +16202,18 @@
             }
         ],
         "spells": [
-            "mage hand", 
-            "minor illusion", 
-            "ray of frost", 
-            "charm person", 
-            "detect magic", 
-            "sleep", 
-            "detect thoughts", 
-            "hold person", 
-            "lightning bolt", 
-            "water breathing", 
-            "blight", 
-            "dimension door", 
+            "mage hand",
+            "minor illusion",
+            "ray of frost",
+            "charm person",
+            "detect magic",
+            "sleep",
+            "detect thoughts",
+            "hold person",
+            "lightning bolt",
+            "water breathing",
+            "blight",
+            "dimension door",
             "dominate person"
         ],
         "actions": [
@@ -16632,11 +16632,11 @@
             }
         ],
         "spells": [
-            "detect magic", 
-            "feather fall", 
-            "levitate", 
-            "light", 
-            "control weather", 
+            "detect magic",
+            "feather fall",
+            "levitate",
+            "light",
+            "control weather",
             "water breathing"
         ],
         "actions": [
@@ -17774,11 +17774,11 @@
             }
         ],
         "spells": [
-            "detect evil and good", 
-            "druidcraft", 
-            "pass without trace", 
-            "calm emotions", 
-            "dispel evil and good", 
+            "detect evil and good",
+            "druidcraft",
+            "pass without trace",
+            "calm emotions",
+            "dispel evil and good",
             "entangle"
         ],
         "actions": [


### PR DESCRIPTION
These are corrections for the SRD monster data. There are just under 20 actual corrections, not counting removing trailing spaces (which are all in the first commit). Of the actual corrections, many of them are whitespace and formatting corrections. Only a couple of substantive error corrections (adult brass dragon bite is the main one).