### PR TITLE
Clarify Air Elemental speed

### DIFF
--- a/data/WOTC_5e_SRD_v5.1/monsters.json
+++ b/data/WOTC_5e_SRD_v5.1/monsters.json
@@ -1216,7 +1216,7 @@
         "armor_class": 15,
         "hit_points": 90,
         "hit_dice": "12d10+24",
-        "speed": "fly 90 ft. (hover)",
+        "speed": "0 ft., fly 90 ft. (hover)",
         "strength": 14,
         "dexterity": 20,
         "constitution": 14,
@@ -1258,6 +1258,7 @@
         ],
         "speed_json": {
             "hover": true,
+            "walk": 0,
             "fly": 90
         },
         "group": "Elementals"


### PR DESCRIPTION
- walk speed is required, even if it is 0.