### PR TITLE
SRD monster attack action corrections

### DIFF
--- a/data/WOTC_5e_SRD_v5.1/monsters.json
+++ b/data/WOTC_5e_SRD_v5.1/monsters.json
@@ -3582,14 +3582,14 @@
             },
             {
                 "name": "Bite",
-                "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
+                "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
                 "attack_bonus": 3,
                 "damage_dice": "1d6",
                 "damage_bonus": 2
             },
             {
                 "name": "Claws",
-                "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) slashing damage.",
+                "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) slashing damage.",
                 "attack_bonus": 3,
                 "damage_dice": "2d4",
                 "damage_bonus": 2
@@ -4143,14 +4143,14 @@
             },
             {
                 "name": "Bite",
-                "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) piercing damage.",
+                "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) piercing damage.",
                 "attack_bonus": 5,
                 "damage_dice": "1d8",
                 "damage_bonus": 4
             },
             {
                 "name": "Claws",
-                "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage.",
+                "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage.",
                 "attack_bonus": 5,
                 "damage_dice": "2d6",
                 "damage_bonus": 4
@@ -5173,7 +5173,7 @@
         "actions": [
             {
                 "name": "Bite",
-                "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 7 (1d10 + 2) piercing damage, and the target is grappled (escape DC 12). Until this grapple ends, the target is restrained, and the crocodile can't bite another target",
+                "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 7 (1d10 + 2) piercing damage, and the target is grappled (escape DC 12). Until this grapple ends, the target is restrained, and the crocodile can't bite another target.",
                 "attack_bonus": 4,
                 "damage_dice": "1d10",
                 "damage_bonus": 2
@@ -5462,7 +5462,7 @@
             },
             {
                 "name": "Poisoned Dart",
-                "desc": "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one creature. Hit: 4 (1d4 + 2) piercing damage, and the target must succeed on a DC 12 Constitution saving throw or be poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success",
+                "desc": "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one creature. Hit: 4 (1d4 + 2) piercing damage, and the target must succeed on a DC 12 Constitution saving throw or be poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
                 "attack_bonus": 4,
                 "damage_dice": "1d4",
                 "damage_bonus": 2
@@ -8499,7 +8499,7 @@
         "actions": [
             {
                 "name": "Bite",
-                "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies.",
+                "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies.",
                 "attack_bonus": 4,
                 "damage_dice": "1d4",
                 "damage_bonus": 2
@@ -8862,7 +8862,7 @@
         "actions": [
             {
                 "name": "Sting",
-                "desc": "Sting. Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.",
+                "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.",
                 "attack_bonus": 4,
                 "damage_dice": "1d6",
                 "damage_bonus": 2
@@ -10031,7 +10031,7 @@
             },
             {
                 "name": "Claw",
-                "desc": "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage.",
+                "desc": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage.",
                 "attack_bonus": 9,
                 "damage_dice": "2d8",
                 "damage_bonus": 4
@@ -10845,7 +10845,7 @@
             },
             {
                 "name": "Tail",
-                "desc": "Melee Weapon Attack:+10 to hit, reach 10 ft., one target. Hit: 12 (2d6 + 5) bludgeoning damage plus 10 (3d6) cold damage.",
+                "desc": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 12 (2d6 + 5) bludgeoning damage plus 10 (3d6) cold damage.",
                 "attack_bonus": 10,
                 "damage_dice": "2d6+3d6",
                 "damage_bonus": 5
@@ -13920,7 +13920,7 @@
             },
             {
                 "name": "Tail",
-                "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 24 (3d1O + 8) bludgeoning damage.",
+                "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 24 (3d10 + 8) bludgeoning damage.",
                 "attack_bonus": 14,
                 "damage_dice": "3d10",
                 "damage_bonus": 8
@@ -15370,7 +15370,7 @@
             },
             {
                 "name": "Shortsword",
-                "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1 d6 + 3) piercing damage.",
+                "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.",
                 "attack_bonus": 5,
                 "damage_dice": "1d6",
                 "damage_bonus": 3
@@ -17579,7 +17579,7 @@
             },
             {
                 "name": "Stomp",
-                "desc": "Melee Weapon Attack: +9 to hit, reach 5 ft., one prone creature. Hit: 22 (3d10 + 6) bludgeoning damage",
+                "desc": "Melee Weapon Attack: +9 to hit, reach 5 ft., one prone creature. Hit: 22 (3d10 + 6) bludgeoning damage.",
                 "attack_bonus": 9,
                 "damage_dice": "3d10",
                 "damage_bonus": 6

--- a/data/WOTC_5e_SRD_v5.1/spells.json
+++ b/data/WOTC_5e_SRD_v5.1/spells.json
@@ -3597,7 +3597,7 @@
     },
     {
         "name": "Phantasmal Killer",
-        "desc": "You tap into the nightmares of a creature you can see within range and create an illusory manifestation of its deepest fears, visible only to that creature. The target must make a wisdom saving throw. On a failed save, the target becomes frightened for the duration. At the start of each of the target's turns before the spell ends, the target must succeed on a wisdom saving throw or take 4 d10 psychic damage. On a successful save, the spell ends.",
+        "desc": "You tap into the nightmares of a creature you can see within range and create an illusory manifestation of its deepest fears, visible only to that creature. The target must make a wisdom saving throw. On a failed save, the target becomes frightened for the duration. At the start of each of the target's turns before the spell ends, the target must succeed on a wisdom saving throw or take 4d10 psychic damage. On a successful save, the spell ends.",
         "higher_level": "When you cast this spell using a spell slot of 5th level or higher, the damage increases by 1d10 for each slot level above 4th.",
         "page": "phb 265",
         "range": "120 feet",
@@ -5214,7 +5214,7 @@
     },
     {
         "name": "Weird",
-        "desc": "Drawing on the deepest fears of a group of creatures, you create illusory creatures in their minds, visible only to them. Each creature in a 30-foot-radius sphere centered on a point of your choice within range must make a wisdom saving throw. On a failed save, a creature becomes frightened for the duration. The illusion calls on the creature's deepest fears, manifesting its worst nightmares as an implacable threat. At the start of each of the frightened creature's turns, it must succeed on a wisdom saving throw or take 4 d10 psychic damage. On a successful save, the spell ends for that creature.",
+        "desc": "Drawing on the deepest fears of a group of creatures, you create illusory creatures in their minds, visible only to them. Each creature in a 30-foot-radius sphere centered on a point of your choice within range must make a wisdom saving throw. On a failed save, a creature becomes frightened for the duration. The illusion calls on the creature's deepest fears, manifesting its worst nightmares as an implacable threat. At the start of each of the frightened creature's turns, it must succeed on a wisdom saving throw or take 4d10 psychic damage. On a successful save, the spell ends for that creature.",
         "page": "phb 288",
         "range": "120 feet",
         "components": "V, S",


### PR DESCRIPTION
- black and brown bear to-hit updates
- add missing periods
- correct average damage for 1d4 + 2 from 3 to 4
- whitespace corrections