### PR TITLE
Correct punctuation for speed.

### DIFF
--- a/data/WOTC_5e_SRD_v5.1/monsters.json
+++ b/data/WOTC_5e_SRD_v5.1/monsters.json
@@ -10407,7 +10407,7 @@
         "armor_class": 11,
         "hit_points": 19,
         "hit_dice": "3d10+3",
-        "speed": "40 ft, fly 60 ft.",
+        "speed": "40 ft., fly 60 ft.",
         "strength": 17,
         "dexterity": 13,
         "constitution": 13,


### PR DESCRIPTION
standardizing speed abbreviation punctuation with 'ft.'